### PR TITLE
8-feat-기상청 api 파주기 연동 및 단기 해상 예보 조회

### DIFF
--- a/.env
+++ b/.env
@@ -3,3 +3,4 @@
 # 기상청 API 인증키
 #
 WEATHER_API_KEY={인증키}
+API_HUB_AUTH_KEY={인증키}

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/Constants.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
             public static final String WATER_TEMP = "/1360000/BeachInfoservice/getTwBuoyBeach";
             public static final String BEACH_FORECAST = "/1360000/BeachInfoservice/getVilageFcstBeach";
             public static final String WAVE_PERIOD = "https://apihub.kma.go.kr/api/typ01/url/kma_buoy.php?";
+            public static final String SHORT_RANGE_FORECAST = "https://apihub.kma.go.kr/api/typ01/url/fct_afs_do.php?";
         }
     }
 

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/Constants.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/Constants.java
@@ -9,6 +9,7 @@ public class Constants {
             public static final String BASE_URL = "https://apis.data.go.kr";
             public static final String WATER_TEMP = "/1360000/BeachInfoservice/getTwBuoyBeach";
             public static final String BEACH_FORECAST = "/1360000/BeachInfoservice/getVilageFcstBeach";
+            public static final String WAVE_PERIOD = "https://apihub.kma.go.kr/api/typ01/url/kma_buoy.php?";
         }
     }
 

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/Constants.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/Constants.java
@@ -33,7 +33,7 @@ public class Constants {
     public static class Unit {
         public static final String CELSIUS = "°C";
         public static final String MS = "m/s";
-        public static final String DEG = "deg"; // TODO: 각도 (추후, W(서), N(북) 등으로 수정 예정)
+        public static final String SECONDS = "S";
         public static final String METER = "M";
     }
 }

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/config/SecurityConfig.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package tourism_data.Surfing_The_Gangwon.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -29,5 +30,10 @@ public class SecurityConfig {
         return WebClient.builder()
                 .baseUrl(WEATHER.BASE_URL)
                 .build();
+    }
+    
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
     }
 }

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/controller/SeashoreController.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/controller/SeashoreController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import tourism_data.Surfing_The_Gangwon.dto.SeashoreDetailResponse;
 import tourism_data.Surfing_The_Gangwon.dto.SeashoreResponse;
+import tourism_data.Surfing_The_Gangwon.dto.response.weather.DailyForecastResponse;
 import tourism_data.Surfing_The_Gangwon.service.SeashoreService;
 
 @RestController
@@ -29,6 +30,12 @@ public class SeashoreController {
     @GetMapping("/seashores/{seashore_id}")
     public ResponseEntity<SeashoreDetailResponse> getSeashoreById(@PathVariable(name = "seashore_id") Long seashoreId) {
         var response = seashoreService.getSeashoreById(seashoreId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/seashores/{beach_code}/forecasts")
+    public ResponseEntity<List<DailyForecastResponse>> getDailyForecasts(@PathVariable(name = "beach_code") Long beachCode) {
+        var response = seashoreService.getDailyRangeForecast(beachCode);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/SeashoreResponse.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/SeashoreResponse.java
@@ -1,8 +1,10 @@
 package tourism_data.Surfing_The_Gangwon.dto;
 
 import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 import tourism_data.Surfing_The_Gangwon.entity.Seashore;
 
+@Slf4j
 @Builder
 public record SeashoreResponse(
     Long id,
@@ -16,7 +18,10 @@ public record SeashoreResponse(
 ) {
 
     public static SeashoreResponse create(Seashore seashore, String waterTemp, BeachForecast forecast,
-        String wavePeriod) {
+        String wavePeriod, String forcast) {
+
+        log.info("forecast Response for seashore {}", forcast);
+
         return SeashoreResponse.builder()
             .id(seashore.getId())
             .name(seashore.getName())

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/SeashoreResponse.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/SeashoreResponse.java
@@ -11,12 +11,12 @@ public record SeashoreResponse(
     String waterTemp, // 수온
     String waveHeight, // 파고
     String windSpeed, //
-    String windDir // 풍향
+    String windDir, // 풍향
+    String wavePeriod // 파주기 (파도가 오는 간격)
 ) {
 
     public static SeashoreResponse create(Seashore seashore, String waterTemp, BeachForecast forecast,
         String wavePeriod) {
-        // TODO
         return SeashoreResponse.builder()
             .id(seashore.getId())
             .name(seashore.getName())
@@ -25,6 +25,7 @@ public record SeashoreResponse(
             .windSpeed(forecast.windSpeed())
             .windDir(forecast.windDir())
             .waterTemp(waterTemp)
+            .wavePeriod(wavePeriod)
             .build();
     }
 }

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/SeashoreResponse.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/SeashoreResponse.java
@@ -14,7 +14,8 @@ public record SeashoreResponse(
     String windDir // 풍향
 ) {
 
-    public static SeashoreResponse create(Seashore seashore, String waterTemp, BeachForecast forecast) {
+    public static SeashoreResponse create(Seashore seashore, String waterTemp, BeachForecast forecast,
+        String wavePeriod) {
         // TODO
         return SeashoreResponse.builder()
             .id(seashore.getId())

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/SeashoreResponse.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/SeashoreResponse.java
@@ -18,10 +18,7 @@ public record SeashoreResponse(
 ) {
 
     public static SeashoreResponse create(Seashore seashore, String waterTemp, BeachForecast forecast,
-        String wavePeriod, String forcast) {
-
-        log.info("forecast Response for seashore {}", forcast);
-
+        String wavePeriod) {
         return SeashoreResponse.builder()
             .id(seashore.getId())
             .name(seashore.getName())

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/request/BaseRequest.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/request/BaseRequest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
+import tourism_data.Surfing_The_Gangwon.util.ApiKeyManager;
+import tourism_data.Surfing_The_Gangwon.util.ApiKeyManager.ApiKeyType;
 
 @Getter
 @SuperBuilder
@@ -16,7 +18,7 @@ public class BaseRequest {
     public static final String BEACH_NUM = "beach_num";
 
     @Builder.Default
-    private String serviceKey = getServiceKeyFromProperties();
+    private String serviceKey = getServiceKey();
     @Builder.Default
     private String numOfRows = "10";
     @Builder.Default
@@ -27,34 +29,7 @@ public class BaseRequest {
     @JsonProperty("beach_num")
     private String beachNum;
 
-    private static String getServiceKeyFromProperties() {
-        // 환경변수에서 API 키 가져오기
-        String apiKey = System.getenv("WEATHER_API_KEY");
-        if (apiKey != null && !apiKey.isEmpty()) {
-            return apiKey;
-        }
-        
-        // VM options에서 API 키 가져오기
-        apiKey = System.getProperty("WEATHER_API_KEY");
-        if (apiKey != null && !apiKey.isEmpty()) {
-            return apiKey;
-        }
-        
-        // .env 파일에서 API 키 가져오기
-        try {
-            java.nio.file.Path envPath = java.nio.file.Paths.get(".env");
-            if (java.nio.file.Files.exists(envPath)) {
-                java.util.List<String> lines = java.nio.file.Files.readAllLines(envPath);
-                for (String line : lines) {
-                    if (line.startsWith("WEATHER_API_KEY=")) {
-                        return line.substring("WEATHER_API_KEY=".length()).trim();
-                    }
-                }
-            }
-        } catch (Exception e) {
-            // .env 파일을 읽을 수 없는 경우 무시
-        }
-        
-        return null;
+    public static String getServiceKey() {
+        return ApiKeyManager.getApiKey(ApiKeyType.WEATHER_API);
     }
 }

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/request/DailyForecastRequest.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/request/DailyForecastRequest.java
@@ -3,7 +3,7 @@ package tourism_data.Surfing_The_Gangwon.dto.request;
 import lombok.Builder;
 
 @Builder
-public record ShortRangeForecastRequest(
+public record DailyForecastRequest(
     String reg, // 예보구역코드
     String tmfc1, // 조회 기간: [tmfc1 ~ tmfc2] : 년월일시(KST)
     String tmfc2, // 조회 기간: [tmfc1 ~ tmfc2] : 년월일시(KST)

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/request/ShortRangeForecastRequest.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/request/ShortRangeForecastRequest.java
@@ -1,0 +1,14 @@
+package tourism_data.Surfing_The_Gangwon.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record ShortRangeForecastRequest(
+    String reg, // 예보구역코드
+    String tmfc1, // 조회 기간: [tmfc1 ~ tmfc2] : 년월일시(KST)
+    String tmfc2, // 조회 기간: [tmfc1 ~ tmfc2] : 년월일시(KST)
+    String disp, // 0 : 변수별로 일정한 길이 유지, 1 : 구분자(,)로 구분
+    String help, // 1(도움말 정보 표시)
+    String authKey // API 인증키
+) {
+}

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/request/WavePeriodRequest.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/request/WavePeriodRequest.java
@@ -1,0 +1,12 @@
+package tourism_data.Surfing_The_Gangwon.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record WavePeriodRequest(
+    String tm, // 년월일시분(KST)
+    Integer stn, // 해당 지점의 정보 표출 (0 이거나 없으면 전체지점)
+    Integer help, // 1 이면 필드에 대한 약간의 도움말 추가 (0 이거나 없으면 없음)
+    String authKey // 발급된 API 인증키
+) {
+}

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/response/weather/DailyForecastResponse.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/response/weather/DailyForecastResponse.java
@@ -1,0 +1,15 @@
+package tourism_data.Surfing_The_Gangwon.dto.response.weather;
+
+import lombok.Builder;
+
+@Builder
+public record DailyForecastResponse(
+    String tmfc, // 발표시각
+    String tmef, // 발효시각
+    String sky, // 하늘상태
+    String w2, // 풍향
+    String s2, // 풍속
+    String wh2, // 파고
+    String wf // 예보
+) {
+}

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/response/weather/DailyForecastResponse.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/response/weather/DailyForecastResponse.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 
 @Builder
 public record DailyForecastResponse(
-    String tmfc, // 발표시각
     String tmef, // 발효시각
     String sky, // 하늘상태
     String w2, // 풍향

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/dto/response/weather/WavePeriodResponse.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/dto/response/weather/WavePeriodResponse.java
@@ -1,0 +1,15 @@
+package tourism_data.Surfing_The_Gangwon.dto.response.weather;
+
+import lombok.Builder;
+import tourism_data.Surfing_The_Gangwon.util.WavePeriodParser;
+
+@Builder
+public record WavePeriodResponse(
+    String wp
+) {
+    public static WavePeriodResponse create(String json) {
+        return WavePeriodResponse.builder()
+            .wp(WavePeriodParser.parseWeatherData(json))
+            .build();
+    }
+}

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
@@ -68,7 +68,7 @@ public class WeatherClient {
                 .uri(uriBuilder -> {
                     return uriBuilder
                             .path(WEATHER.WATER_TEMP)
-                            .queryParam(BaseRequest.SERVICE_KEY, UriUtils.decode(request.getServiceKey(), StandardCharsets.UTF_8))
+                            .queryParam(BaseRequest.SERVICE_KEY, UriUtils.decode(BaseRequest.getServiceKey(), StandardCharsets.UTF_8))
                             .queryParam(BaseRequest.PAGE_NO, request.getPageNo())
                             .queryParam(BaseRequest.NUM_OF_ROWS, request.getNumOfRows())
                             .queryParam(BaseRequest.DATA_TYPE, request.getDataType())

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import tourism_data.Surfing_The_Gangwon.Constants.URL.WEATHER;
 import tourism_data.Surfing_The_Gangwon.dto.request.BaseRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.BeachForecastRequest;
+import tourism_data.Surfing_The_Gangwon.dto.request.ShortRangeForecastRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WaterTempRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WavePeriodRequest;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.BeachForecastResponse;
@@ -23,6 +24,24 @@ public class WeatherClient {
 
     public WeatherClient(WebClient webClient) {
         this.webClient = webClient;
+    }
+
+    public String getShortRangeForecast(ShortRangeForecastRequest request) {
+        String fullUrl = String.format("%sreg=%s&tmfc1=%s&tmfc2=%s&disp=%s&help=%s&authKey=%s",
+            WEATHER.SHORT_RANGE_FORECAST,
+            request.reg(),
+            request.tmfc1(),
+            request.tmfc2(),
+            request.disp(),
+            request.help(),
+            request.authKey());
+
+        return webClient.get()
+            .uri(fullUrl)
+            .retrieve()
+            .bodyToMono(String.class)
+            .timeout(Duration.ofSeconds(30))
+            .block();
     }
 
     public String getWavePeriod(WavePeriodRequest request) {

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriUtils;
+import java.time.Duration;
 import tourism_data.Surfing_The_Gangwon.Constants.URL.WEATHER;
 import tourism_data.Surfing_The_Gangwon.dto.request.BaseRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.BeachForecastRequest;
@@ -42,6 +43,7 @@ public class WeatherClient {
             .uri(fullUrl)
             .retrieve()
             .bodyToMono(String.class)
+            .timeout(Duration.ofSeconds(30))
             .block();
 
         log.info("Raw CSV Response: {}", csvResponse);
@@ -85,6 +87,7 @@ public class WeatherClient {
                 })
                 .retrieve()
                 .bodyToMono(WaterTempResponse.class)
+                .timeout(Duration.ofSeconds(30))
                 .block();
 
         if (response == null) {
@@ -110,6 +113,7 @@ public class WeatherClient {
             })
             .retrieve()
             .bodyToMono(BeachForecastResponse.class)
+            .timeout(Duration.ofSeconds(30))
             .block();
 
         if (response == null) {

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
@@ -8,7 +8,7 @@ import java.time.Duration;
 import tourism_data.Surfing_The_Gangwon.Constants.URL.WEATHER;
 import tourism_data.Surfing_The_Gangwon.dto.request.BaseRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.BeachForecastRequest;
-import tourism_data.Surfing_The_Gangwon.dto.request.ShortRangeForecastRequest;
+import tourism_data.Surfing_The_Gangwon.dto.request.DailyForecastRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WaterTempRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WavePeriodRequest;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.BeachForecastResponse;
@@ -26,7 +26,7 @@ public class WeatherClient {
         this.webClient = webClient;
     }
 
-    public String getShortRangeForecast(ShortRangeForecastRequest request) {
+    public String getDailyRangeForecast(DailyForecastRequest request) {
         String fullUrl = String.format("%sreg=%s&tmfc1=%s&tmfc2=%s&disp=%s&help=%s&authKey=%s",
             WEATHER.SHORT_RANGE_FORECAST,
             request.reg(),

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
@@ -8,11 +8,15 @@ import tourism_data.Surfing_The_Gangwon.Constants.URL.WEATHER;
 import tourism_data.Surfing_The_Gangwon.dto.request.BaseRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.BeachForecastRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WaterTempRequest;
+import tourism_data.Surfing_The_Gangwon.dto.request.WavePeriodRequest;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.BeachForecastResponse;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.WaterTempResponse;
 
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @Slf4j
 @Component
@@ -22,6 +26,26 @@ public class WeatherClient {
 
     public WeatherClient(WebClient webClient) {
         this.webClient = webClient;
+    }
+
+    public String getWavePeriod(WavePeriodRequest request) {
+        String fullUrl = String.format("%stm=%s&stn=%d&help=%d&authKey=%s",
+            WEATHER.WAVE_PERIOD,
+            request.tm(),
+            request.stn(),
+            request.help(),
+            request.authKey());
+        
+        log.info("API Request URL: {}", fullUrl);
+        
+        String csvResponse = webClient.get()
+            .uri(fullUrl)
+            .retrieve()
+            .bodyToMono(String.class)
+            .block();
+
+        log.info("Raw CSV Response: {}", csvResponse);
+        return csvResponse;
     }
 
     public WaterTempResponse getWeaterTemp(WaterTempRequest request) {

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/integration/WeatherClient.java
@@ -14,10 +14,6 @@ import tourism_data.Surfing_The_Gangwon.dto.response.weather.BeachForecastRespon
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.WaterTempResponse;
 
 import java.nio.charset.StandardCharsets;
-import java.util.*;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @Slf4j
 @Component
@@ -36,18 +32,13 @@ public class WeatherClient {
             request.stn(),
             request.help(),
             request.authKey());
-        
-        log.info("API Request URL: {}", fullUrl);
-        
-        String csvResponse = webClient.get()
+
+        return webClient.get()
             .uri(fullUrl)
             .retrieve()
             .bodyToMono(String.class)
             .timeout(Duration.ofSeconds(30))
             .block();
-
-        log.info("Raw CSV Response: {}", csvResponse);
-        return csvResponse;
     }
 
     public WaterTempResponse getWeaterTemp(WaterTempRequest request) {

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/mapper/BeachRegIdMapper.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/mapper/BeachRegIdMapper.java
@@ -1,0 +1,37 @@
+package tourism_data.Surfing_The_Gangwon.mapper;
+
+import java.util.Arrays;
+import java.util.Set;
+
+/**
+ * (기간별 단기 해상 예보 조회 시 사용)
+ * Seashore 엔티티의 beachCode 필드에 따른 해양 기상 에보구역 코드 매핑
+ * 그러나 해변이 계속 늘어날 수록 수동적으로 값을 추가해줄 수 없기에 따로 DB 테이블로 분리 필요
+ *
+ * 강원 북부 : 12C20103
+ * 강원 중부 : 12C20102
+ * 강원 남부: 12C20101 (추후 추가 예정)
+ */
+public enum BeachRegIdMapper {
+    SOKCHO("12C20103", Set.of()),
+    GANGNEUNG("12C20102", Set.of("176", "179", "172", "174")),
+    YANGYANG("12C20103", Set.of("249", "250", "262", "263"));
+
+    // 예보구역 코드
+    private final String regId;
+    // 해당 관측지점 지역에 해당하는 해변 코드들 집합
+    private final Set<String> beachCodes;
+
+    BeachRegIdMapper(String regId, Set<String> beachCodes) {
+        this.regId = regId;
+        this.beachCodes = beachCodes;
+    }
+
+    public static String getRegId(String beachCode) {
+        return Arrays.stream(values())
+            .filter(mapper -> mapper.beachCodes.contains(beachCode))
+            .findFirst()
+            .map(beach -> beach.regId)
+            .orElse(null);
+    }
+}

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/mapper/BeachStationMapper.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/mapper/BeachStationMapper.java
@@ -1,0 +1,33 @@
+package tourism_data.Surfing_The_Gangwon.mapper;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Seashore 엔티티의 beachCode 필드에 따른 해양 기상 관측지점 코드 매핑
+ * 그러나 해변이 계속 늘어날 수록 수동적으로 값을 추가해줄 수 없기에 따로 DB 테이블로 분리 필요
+ */
+public enum BeachStationMapper {
+    SOKCHO("22310", Set.of()),
+    GANGNEUNG("22311", Set.of("176", "179", "172", "174")),
+    YANGYANG("22305", Set.of("249", "250", "262", "263"));
+
+    // 관측지점 코드
+    private final String stationCode;
+    // 해당 관측지점 지역에 해당하는 해변 코드들 집합
+    private final Set<String> beachCodes;
+
+    BeachStationMapper(String stationCode, Set<String> beachCodes) {
+        this.stationCode = stationCode;
+        this.beachCodes = beachCodes;
+    }
+
+    public static Integer getStationCode(String beachCode) {
+        return Integer.valueOf(Objects.requireNonNull(Arrays.stream(values())
+            .filter(mapper -> mapper.beachCodes.contains(beachCode))
+            .findFirst()
+            .map(beach -> beach.stationCode)
+            .orElse(null)));
+    }
+}

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/mapper/BeachStationMapper.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/mapper/BeachStationMapper.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
+ * (파도 주기 요청 시 사용)
  * Seashore 엔티티의 beachCode 필드에 따른 해양 기상 관측지점 코드 매핑
  * 그러나 해변이 계속 늘어날 수록 수동적으로 값을 추가해줄 수 없기에 따로 DB 테이블로 분리 필요
  */

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
@@ -20,6 +20,8 @@ import tourism_data.Surfing_The_Gangwon.entity.Seashore;
 import tourism_data.Surfing_The_Gangwon.integration.WeatherClient;
 import tourism_data.Surfing_The_Gangwon.mapper.BeachStationMapper;
 import tourism_data.Surfing_The_Gangwon.repository.SeashoreRepository;
+import tourism_data.Surfing_The_Gangwon.util.ApiKeyManager;
+import tourism_data.Surfing_The_Gangwon.util.ApiKeyManager.ApiKeyType;
 
 @Service
 public class SeashoreService {
@@ -102,41 +104,14 @@ public class SeashoreService {
             .tm(searchTime)
             .stn(stnCode)
             .help(0)
-            .authKey(getWavePeriodAuthKeyFromProperties())
+            .authKey(getApiHubAuthKey())
             .build();
 
         WavePeriodResponse response = WavePeriodResponse.create(weatherClient.getWavePeriod(request));
         return response.wp() + Unit.SECONDS;
     }
 
-    public static String getWavePeriodAuthKeyFromProperties() {
-        // 환경변수에서 파주기 API 키 가져오기
-        String authKey = System.getenv("API_HUB_AUTH_KEY");
-        if (authKey != null && !authKey.isEmpty()) {
-            return authKey;
-        }
-
-        // VM options에서 파주기 API 키 가져오기
-        authKey = System.getProperty("API_HUB_AUTH_KEY");
-        if (authKey != null && !authKey.isEmpty()) {
-            return authKey;
-        }
-
-        // .env 파일에서 파주기 API 키 가져오기
-        try {
-            java.nio.file.Path envPath = java.nio.file.Paths.get(".env");
-            if (java.nio.file.Files.exists(envPath)) {
-                java.util.List<String> lines = java.nio.file.Files.readAllLines(envPath);
-                for (String line : lines) {
-                    if (line.startsWith("API_HUB_AUTH_KEY=")) {
-                        return line.substring("API_HUB_AUTH_KEY=".length()).trim();
-                    }
-                }
-            }
-        } catch (Exception e) {
-            // .env 파일을 읽을 수 없는 경우 무시
-        }
-
-        return null;
+    public static String getApiHubAuthKey() {
+        return ApiKeyManager.getApiKey(ApiKeyType.HUB_API);
     }
 }

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
@@ -11,6 +11,7 @@ import tourism_data.Surfing_The_Gangwon.dto.SeashoreResponse;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import tourism_data.Surfing_The_Gangwon.dto.request.BeachForecastRequest;
+import tourism_data.Surfing_The_Gangwon.dto.request.ShortRangeForecastRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WaterTempRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WavePeriodRequest;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.BeachForecastResponse;
@@ -18,6 +19,7 @@ import tourism_data.Surfing_The_Gangwon.dto.response.weather.WaterTempResponse;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.WavePeriodResponse;
 import tourism_data.Surfing_The_Gangwon.entity.Seashore;
 import tourism_data.Surfing_The_Gangwon.integration.WeatherClient;
+import tourism_data.Surfing_The_Gangwon.mapper.BeachRegIdMapper;
 import tourism_data.Surfing_The_Gangwon.mapper.BeachStationMapper;
 import tourism_data.Surfing_The_Gangwon.repository.SeashoreRepository;
 import tourism_data.Surfing_The_Gangwon.util.ApiKeyManager;
@@ -109,6 +111,26 @@ public class SeashoreService {
 
         WavePeriodResponse response = WavePeriodResponse.create(weatherClient.getWavePeriod(request));
         return response.wp() + Unit.SECONDS;
+    }
+
+    // 단기 해상 예보 조회
+    private String getShortRangeForecast(Integer beachCode) {
+        var startDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
+        var endDateTime = LocalDateTime.now().plusDays(3).format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
+        var start = startDateTime.substring(0, 10);
+        var end = endDateTime.substring(0, 10);
+
+        var regId = BeachRegIdMapper.getRegId(String.valueOf(beachCode));
+        ShortRangeForecastRequest request = ShortRangeForecastRequest.builder()
+            .reg(regId)
+            .tmfc1(start)
+            .tmfc2(end)
+            .disp("0")
+            .help("0")
+            .authKey(getApiHubAuthKey())
+            .build();
+
+        return "";
     }
 
     public static String getApiHubAuthKey() {

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
@@ -2,6 +2,7 @@ package tourism_data.Surfing_The_Gangwon.service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
 import tourism_data.Surfing_The_Gangwon.Constants.Format;
 import tourism_data.Surfing_The_Gangwon.Constants.Time;
 import tourism_data.Surfing_The_Gangwon.Constants.Unit;
@@ -25,6 +26,7 @@ import tourism_data.Surfing_The_Gangwon.repository.SeashoreRepository;
 import tourism_data.Surfing_The_Gangwon.util.ApiKeyManager;
 import tourism_data.Surfing_The_Gangwon.util.ApiKeyManager.ApiKeyType;
 
+@Slf4j
 @Service
 public class SeashoreService {
     private final SeashoreRepository seashoreRepository;
@@ -36,12 +38,14 @@ public class SeashoreService {
     }
 
     public List<SeashoreResponse> getSeashoresByCity(Long cityId) {
+
         return seashoreRepository.findByCityId(cityId)
             .stream()
             .map((Seashore seashore) -> {
                 BeachForecastResponse forecastResponse = getBeachForecast(seashore.getBeachCode());
                 return SeashoreResponse.create(seashore, getWaterTemp(seashore.getBeachCode()),
-                    BeachForecast.create(forecastResponse), getWavePeriod(seashore.getBeachCode())
+                    BeachForecast.create(forecastResponse), getWavePeriod(seashore.getBeachCode()),
+                    getShortRangeForecast(seashore.getBeachCode())
                 );
             })
             .toList();
@@ -116,7 +120,7 @@ public class SeashoreService {
     // 단기 해상 예보 조회
     private String getShortRangeForecast(Integer beachCode) {
         var startDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
-        var endDateTime = LocalDateTime.now().plusDays(3).format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
+        var endDateTime = LocalDateTime.now().plusDays(2).format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
         var start = startDateTime.substring(0, 10);
         var end = endDateTime.substring(0, 10);
 
@@ -130,7 +134,9 @@ public class SeashoreService {
             .authKey(getApiHubAuthKey())
             .build();
 
-        return "";
+        var response = weatherClient.getShortRangeForecast(request);
+        log.info(response);
+        return response;
     }
 
     public static String getApiHubAuthKey() {

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import tourism_data.Surfing_The_Gangwon.dto.request.BeachForecastRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WaterTempRequest;
+import tourism_data.Surfing_The_Gangwon.dto.request.WavePeriodRequest;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.BeachForecastResponse;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.WaterTempResponse;
 import tourism_data.Surfing_The_Gangwon.entity.Seashore;
@@ -34,7 +35,7 @@ public class SeashoreService {
             .map((Seashore seashore) -> {
                 BeachForecastResponse forecastResponse = getBeachForecast(seashore.getBeachCode());
                 return SeashoreResponse.create(seashore, getWaterTemp(seashore.getBeachCode()),
-                    BeachForecast.create(forecastResponse)
+                    BeachForecast.create(forecastResponse), getWavePeriod(seashore.getBeachCode())
                 );
             })
             .toList();
@@ -91,6 +92,14 @@ public class SeashoreService {
     }
 
     private String getWavePeriod(Integer beachCode) {
-        return "";
+        var searchTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
+        WavePeriodRequest request = WavePeriodRequest.builder()
+            .tm(searchTime)
+            .stn(0)
+            .help(0)
+            .authKey("0nCxR-PFQiSwsUfjxcIkZA")
+            .build();
+
+        return weatherClient.getWavePeriod(request);
     }
 }

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
@@ -12,7 +12,7 @@ import tourism_data.Surfing_The_Gangwon.dto.SeashoreResponse;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import tourism_data.Surfing_The_Gangwon.dto.request.BeachForecastRequest;
-import tourism_data.Surfing_The_Gangwon.dto.request.ShortRangeForecastRequest;
+import tourism_data.Surfing_The_Gangwon.dto.request.DailyForecastRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WaterTempRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WavePeriodRequest;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.BeachForecastResponse;
@@ -45,7 +45,7 @@ public class SeashoreService {
                 BeachForecastResponse forecastResponse = getBeachForecast(seashore.getBeachCode());
                 return SeashoreResponse.create(seashore, getWaterTemp(seashore.getBeachCode()),
                     BeachForecast.create(forecastResponse), getWavePeriod(seashore.getBeachCode()),
-                    getShortRangeForecast(seashore.getBeachCode())
+                    getDailyRangeForecast(seashore.getBeachCode())
                 );
             })
             .toList();
@@ -118,14 +118,14 @@ public class SeashoreService {
     }
 
     // 단기 해상 예보 조회
-    private String getShortRangeForecast(Integer beachCode) {
+    private String getDailyRangeForecast(Integer beachCode) {
         var startDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
         var endDateTime = LocalDateTime.now().plusDays(2).format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
         var start = startDateTime.substring(0, 10);
         var end = endDateTime.substring(0, 10);
 
         var regId = BeachRegIdMapper.getRegId(String.valueOf(beachCode));
-        ShortRangeForecastRequest request = ShortRangeForecastRequest.builder()
+        DailyForecastRequest request = DailyForecastRequest.builder()
             .reg(regId)
             .tmfc1(start)
             .tmfc2(end)
@@ -134,7 +134,7 @@ public class SeashoreService {
             .authKey(getApiHubAuthKey())
             .build();
 
-        var response = weatherClient.getShortRangeForecast(request);
+        var response = weatherClient.getDailyRangeForecast(request);
         log.info(response);
         return response;
     }

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
@@ -16,6 +16,7 @@ import tourism_data.Surfing_The_Gangwon.dto.request.DailyForecastRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WaterTempRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WavePeriodRequest;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.BeachForecastResponse;
+import tourism_data.Surfing_The_Gangwon.dto.response.weather.DailyForecastResponse;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.WaterTempResponse;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.WavePeriodResponse;
 import tourism_data.Surfing_The_Gangwon.entity.Seashore;
@@ -25,6 +26,7 @@ import tourism_data.Surfing_The_Gangwon.mapper.BeachStationMapper;
 import tourism_data.Surfing_The_Gangwon.repository.SeashoreRepository;
 import tourism_data.Surfing_The_Gangwon.util.ApiKeyManager;
 import tourism_data.Surfing_The_Gangwon.util.ApiKeyManager.ApiKeyType;
+import tourism_data.Surfing_The_Gangwon.util.DailyForecastParser;
 
 @Slf4j
 @Service
@@ -44,8 +46,7 @@ public class SeashoreService {
             .map((Seashore seashore) -> {
                 BeachForecastResponse forecastResponse = getBeachForecast(seashore.getBeachCode());
                 return SeashoreResponse.create(seashore, getWaterTemp(seashore.getBeachCode()),
-                    BeachForecast.create(forecastResponse), getWavePeriod(seashore.getBeachCode()),
-                    getDailyRangeForecast(seashore.getBeachCode())
+                    BeachForecast.create(forecastResponse), getWavePeriod(seashore.getBeachCode())
                 );
             })
             .toList();
@@ -118,9 +119,9 @@ public class SeashoreService {
     }
 
     // 단기 해상 예보 조회
-    private String getDailyRangeForecast(Integer beachCode) {
-        var startDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
-        var endDateTime = LocalDateTime.now().plusDays(2).format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
+    public List<DailyForecastResponse> getDailyRangeForecast(Long beachCode) {
+        var startDateTime = LocalDateTime.now().minusDays(1).format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
+        var endDateTime = LocalDateTime.now().plusDays(4).format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
         var start = startDateTime.substring(0, 10);
         var end = endDateTime.substring(0, 10);
 
@@ -135,8 +136,7 @@ public class SeashoreService {
             .build();
 
         var response = weatherClient.getDailyRangeForecast(request);
-        log.info(response);
-        return response;
+        return DailyForecastParser.parseWeatherData(response);
     }
 
     public static String getApiHubAuthKey() {

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/service/SeashoreService.java
@@ -15,6 +15,7 @@ import tourism_data.Surfing_The_Gangwon.dto.request.WaterTempRequest;
 import tourism_data.Surfing_The_Gangwon.dto.request.WavePeriodRequest;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.BeachForecastResponse;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.WaterTempResponse;
+import tourism_data.Surfing_The_Gangwon.dto.response.weather.WavePeriodResponse;
 import tourism_data.Surfing_The_Gangwon.entity.Seashore;
 import tourism_data.Surfing_The_Gangwon.integration.WeatherClient;
 import tourism_data.Surfing_The_Gangwon.repository.SeashoreRepository;
@@ -95,11 +96,12 @@ public class SeashoreService {
         var searchTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(Format.DATE_FORMAT_ONE_LINE));
         WavePeriodRequest request = WavePeriodRequest.builder()
             .tm(searchTime)
-            .stn(0)
+            .stn(0) // TODO : 지역별 지점번호 넣기
             .help(0)
             .authKey("0nCxR-PFQiSwsUfjxcIkZA")
             .build();
 
-        return weatherClient.getWavePeriod(request);
+        WavePeriodResponse response = WavePeriodResponse.create(weatherClient.getWavePeriod(request));
+        return response.wp();
     }
 }

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/util/ApiKeyManager.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/util/ApiKeyManager.java
@@ -1,0 +1,76 @@
+package tourism_data.Surfing_The_Gangwon.util;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ApiKeyManager {
+    public enum ApiKeyType {
+        // 기상청 날씨누리
+        WEATHER_API("WEATHER_API_KEY"),
+        // 기상청 API 허브
+        HUB_API("API_HUB_AUTH_KEY");
+
+        private final String keyName;
+
+        ApiKeyType(String keyName) {
+            this.keyName = keyName;
+        }
+
+        public String getKeyName() {
+            return keyName;
+        }
+    }
+
+    public static String getApiKey(ApiKeyType keyType) {
+        String keyName = keyType.getKeyName();
+
+        // 환경변수에서 API 키 가져오기
+        String apiKey = System.getenv(keyName);
+        if (isValid(apiKey)) {
+            return apiKey;
+        }
+
+        // VM Options에서 API 키 가져오기
+        apiKey = System.getProperty(keyName);
+        if (isValid(apiKey)) {
+            return apiKey;
+        }
+
+        // .env에서 API 키 가져오기
+        apiKey = getApiKeyFromEnvFile(keyName);
+        if (isValid(apiKey)) {
+            return apiKey;
+        }
+
+        log.warn("API Key not found : {}", keyName);
+        return  null;
+    }
+
+    private static boolean isValid(String key) {
+        return key != null && !key.trim().isEmpty();
+    }
+
+    private static String getApiKeyFromEnvFile(String keyName) {
+        try {
+            Path envPath = Paths.get(".env");
+            if (Files.exists(envPath)) {
+                List<String> lines = Files.readAllLines(envPath);
+                String prefix = keyName + "=";
+
+                for (String line : lines) {
+                    if (line.startsWith(prefix)) {
+                        return line.substring(prefix.length()).trim();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Failed to read .env file: {}", e.getMessage());
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/util/DailyForecastParser.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/util/DailyForecastParser.java
@@ -1,0 +1,86 @@
+package tourism_data.Surfing_The_Gangwon.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+import tourism_data.Surfing_The_Gangwon.dto.response.weather.DailyForecastResponse;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class DailyForecastParser {
+
+    private final ObjectMapper objectMapper;
+
+    public DailyForecastParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public static List<DailyForecastResponse> parseWeatherData(String rawData) {
+        List<DailyForecastResponse> weatherDataList = new ArrayList<>();
+
+        String cleanedData = cleanData(rawData);
+        String[] lines = cleanedData.split("\n");
+
+        for (String line : lines) {
+            if (isDataLine(line)) {
+                DailyForecastResponse data = parseLine(line);
+                if (data != null) {
+                    weatherDataList.add(data);
+                }
+            }
+        }
+
+        return weatherDataList;
+    }
+
+    private static String cleanData(String rawData) {
+        rawData = rawData.replace("#START7777", "")
+            .replace("#7777END", "");
+
+        return Arrays.stream(rawData.split("\n"))
+            .filter(line -> !line.startsWith("#"))
+            .collect(Collectors.joining("\n"));
+    }
+
+    private static boolean isDataLine(String line) {
+        return line.matches("^\\w+\\s+\\d{12}.*");
+    }
+
+    private static DailyForecastResponse parseLine(String line) {
+        String[] values = line.trim().split("\\s+");
+
+        if (values.length < 19) {
+            return null;
+        }
+
+        try {
+            String wf = extractQuotedString(line);
+            
+            return DailyForecastResponse.builder()
+                .tmfc(values[1])    // 발표시각
+                .tmef(values[2])    // 발효시각
+                .sky(values[14])    // 하늘상태
+                .w2(values[12])     // 풍향
+                .s2(values[13])     // 풍속
+                .wh2(values[16])    // 파고
+                .wf(wf)             // 예보
+                .build();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String extractQuotedString(String line) {
+        int firstQuote = line.indexOf('"');
+        int lastQuote = line.lastIndexOf('"');
+        
+        if (firstQuote != -1 && lastQuote != -1 && firstQuote != lastQuote) {
+            return line.substring(firstQuote + 1, lastQuote);
+        }
+        return "";
+    }
+}

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/util/DailyForecastParser.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/util/DailyForecastParser.java
@@ -1,23 +1,14 @@
 package tourism_data.Surfing_The_Gangwon.util;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;
 import tourism_data.Surfing_The_Gangwon.dto.response.weather.DailyForecastResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
 public class DailyForecastParser {
-
-    private final ObjectMapper objectMapper;
-
-    public DailyForecastParser(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
 
     public static List<DailyForecastResponse> parseWeatherData(String rawData) {
         List<DailyForecastResponse> weatherDataList = new ArrayList<>();
@@ -61,13 +52,12 @@ public class DailyForecastParser {
             String wf = extractQuotedString(line);
             
             return DailyForecastResponse.builder()
-                .tmfc(values[1])    // 발표시각
-                .tmef(values[2])    // 발효시각
-                .sky(values[14])    // 하늘상태
-                .w2(values[12])     // 풍향
-                .s2(values[13])     // 풍속
-                .wh2(values[16])    // 파고
-                .wf(wf)             // 예보
+                .tmef(values[2]) // 발효시각
+                .sky(values[16]) // 하늘상태
+                .w2(values[11]) // 풍향
+                .s2(values[13]) // 풍속
+                .wh2(values[15]) // 파고
+                .wf(wf) // 예보
                 .build();
         } catch (Exception e) {
             return null;

--- a/src/main/java/tourism_data/Surfing_The_Gangwon/util/WavePeriodParser.java
+++ b/src/main/java/tourism_data/Surfing_The_Gangwon/util/WavePeriodParser.java
@@ -1,0 +1,67 @@
+package tourism_data.Surfing_The_Gangwon.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class WavePeriodParser {
+    public static String parseWeatherData(String rawData) {
+        List<String> weatherDataList = new ArrayList<>();
+
+        // 데이터 정제
+        String cleanedData = cleanData(rawData);
+        String[] lines = cleanedData.split("\n");
+
+        for (String line : lines) {
+            if (isDataLine(line)) {
+                var data = parseLine(line);
+                if (data != null) { weatherDataList.add(data); }
+            }
+        }
+
+        return weatherDataList.getLast();
+    }
+
+    private static String cleanData(String rawData) {
+        // START/END 마커 제거
+        rawData = rawData.replace("#START7777", "")
+            .replace("#7777END", "");
+
+        // 주석 라인 제거
+        return Arrays.stream(rawData.split("\n"))
+            .filter(line -> !line.startsWith("#"))
+            .collect(Collectors.joining("\n"));
+    }
+
+    private static boolean isDataLine(String line) {
+        // 날짜로 시작하는 라인만 데이터로 처리
+        return line.matches("^\\d{12}.*");
+    }
+
+    private static String parseLine(String line) {
+        // 공백으로 분리 (여러 공백을 하나로)
+        String[] values = line.trim().split("\\s+");
+
+        if (values.length < 17) {
+            return null; // 필수 필드가 부족한 경우
+        }
+
+        try {
+            return filterData(values[15]);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String filterData(String value) {
+        if ("-99".equals(value) || "-99.0".equals(value)) {
+            return null; // 결측값 필터 처리
+        }
+        try {
+            return value;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
# 🌟 풀 리퀘스트

## 🌐 연관 이슈 번호
- #8 

## 💬 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성 -->
- 기상청 API 인증키 설정
- 파주기 API 호출 및 CSV 파싱
- 해수욕장별 예보(오늘 기준) 조회 테스트 (기온, 파고, 풍향, 풍속)
- 수온 데이터 조회 및 매
- 해상 단기예보 5일 기준 조회 기능
- 해양 기상관측지점 코드/예보구역 코드 매핑

## 💫 타입

- [x] 기능
- [ ] 버그
- [ ] 테스트
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 기타(환경) 